### PR TITLE
fix: Handle skipped onRequest hook.

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,8 @@ async function fastifyQueue (fastify, options) {
   })
 
   fastify.addHook('onResponse', async (request, reply) => {
-    const queue = reply[queueName]
-    if (!queue[kIsResolved]) {
+    const queue = reply[queueName] || {}
+    if (queue[kIsResolved] === false) {
       await queue.resolve()
     }
   })


### PR DESCRIPTION
### Summary
Resolves an issue where `TypeError: Cannot read property 'Symbol(fastify-queue.isResolved)' of null` was occurring on `OPTIONS` requests in apps that register `fastify-cors` before `fastify-queue`. This was due to the `fastify-cors` `onRequest` hook sending a reply causing the `fastify-queue` `onRequest` hook to be skipped. The `onResponse` hook would then be called and was not able to handle a `null` `reply.queue`.